### PR TITLE
Add TextHelpRecognizer for determining SMS help command help text

### DIFF
--- a/lib/pairing/text_help_recognizer.rb
+++ b/lib/pairing/text_help_recognizer.rb
@@ -1,0 +1,25 @@
+class TextHelpRecognizer
+    BP_HELP = 'To enter blood pressure, text \'bp ###/##\''
+    FG_HELP = 'To enter fasting glucose, text \'fgc ###\''
+    WEIGHT_HELP = 'To enter weight, text \'wt to ###.#\''
+    LONG_FORM_HELP = "For help with blood pressure, text 'help bp', for help with weight, type 'help weight', for help with fasting glucose, type 'help fgc'"
+
+    attr_accessor :help_text
+
+    def initialize(message)
+        command = /^help\s+(bp|fgc|wt)$/.match(message)
+        if command
+            subcommand = command[1]
+
+            if subcommand == "bp"
+                @help_text = BP_HELP
+            elsif subcommand == "fgc"
+                @help_text = FG_HELP
+            elsif subcommand == "wt"
+                @help_text = WEIGHT_HELP
+            end
+        else
+            @help_text = LONG_FORM_HELP
+        end
+    end
+end

--- a/spec/text_help_recognizer_spec.rb
+++ b/spec/text_help_recognizer_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+describe 'TextHelpRecognizer' do
+    it "should set help_text to long form help when passed gibberish" do
+        message = "ssasasads"
+        recognizer = TextHelpRecognizer.new(message)
+
+        expect(recognizer.help_text).to eq(TextHelpRecognizer::LONG_FORM_HELP)
+    end
+
+    it "should set help_text to blood pressure help when passed 'help bp'" do
+        message = "help bp"
+        recognizer = TextHelpRecognizer.new(message)
+
+        expect(recognizer.help_text).to eq(TextHelpRecognizer::BP_HELP)
+    end
+
+    it "should set help_text to fasting glucose help when passed 'help fgc'" do
+        message = "help fgc"
+        recognizer = TextHelpRecognizer.new(message)
+
+        expect(recognizer.help_text).to eq(TextHelpRecognizer::FG_HELP)
+    end
+
+    it "should set help_text to weight help when passed 'help wt'" do
+        message = "help wt"
+        recognizer = TextHelpRecognizer.new(message)
+
+        expect(recognizer.help_text).to eq(TextHelpRecognizer::WEIGHT_HELP)
+    end
+
+    it "should require a space between 'help' arguments" do
+        message = "helpybp"
+        recognizer = TextHelpRecognizer.new(message)
+
+        expect(recognizer.help_text).to eq(TextHelpRecognizer::LONG_FORM_HELP)
+    end
+
+    it "should not recognize erronious characters after the subcommand" do
+        message = "help wtttttttt"
+        recognizer = TextHelpRecognizer.new(message)
+
+        expect(recognizer.help_text).to eq(TextHelpRecognizer::LONG_FORM_HELP)
+    end
+end


### PR DESCRIPTION
Provides a long form help summary in case of unrecognized input.
Includes passing tests! :D

Signed-off-by: Max Fierke max@maxfierke.com
